### PR TITLE
Minor Fix

### DIFF
--- a/lib/base62.rb
+++ b/lib/base62.rb
@@ -88,7 +88,7 @@ class Integer
      result = ''
      while(number != 0)
         result = BASE62_PRIMITIVES[number % BASE62_PRIMITIVES.size ].to_s + result
-        number /= BASE62_PRIMITIVES.size
+        number = Integer(number / BASE62_PRIMITIVES.size)
      end
     result
   end


### PR DESCRIPTION
Hi JT,

The line I changed was causing problems in rails 3.0.7 with ruby 1.9.2-p0. The result of the divide operation was a Rational instead of an Integer and so the while loop never terminates. Maybe ActiveSupport modifies normal Fixnum behaviour...? Anyway, manually casting the result as an Integer fixes the problem.

Thanks for this gem BTW, very useful...

Cheers,

Jon
